### PR TITLE
Added binmode(OUT)

### DIFF
--- a/tools/msgconvert.pl
+++ b/tools/msgconvert.pl
@@ -43,6 +43,7 @@ foreach my $file (@ARGV) {
     my $outfile = "$basename.mime";
     open OUT, ">:utf8", $outfile
       or die "Can't open $outfile for writing: $!";
+    binmode(OUT);  
     print OUT $mail->as_string;
     close OUT;
   }


### PR DESCRIPTION
I had an issue on Windows Perl (ActiveState and Strawberry, but not in Cygwin Perl) where the output file would have extra carriage return characters at the end of each line. Basically I would get a \r\r\n instead of \r\n . This prevented me from generating correctly formatted files. I think this is due to Email::Stuff trying to replace \n with \r\n (see http://www.perlmonks.org/bare/?node_id=817711). I added binmode to fix this issue.
